### PR TITLE
refactor(nowcasting): split disease pipeline and reduce memory retention

### DIFF
--- a/docs/pipe_nowcasting/main_BR_stability_report.md
+++ b/docs/pipe_nowcasting/main_BR_stability_report.md
@@ -1,0 +1,452 @@
+## Summary: nowcasting pipeline memory and stability investigation
+
+### Initial problem
+
+The `refresh-alertas` / `main_BR.R` nowcasting pipeline was failing during execution when running multiple states in parallel. The first visible failure was generic:
+
+```text
+Warning message:
+In parallel::mclapply(...):
+  1 function calls resulted in an error
+
+Error: State pipeline failed for: CE / AL
+```
+
+The failure was hard to debug because `parallel::mclapply()` returned only a generic worker error. The real failing step, state, disease, municipality, and internal error were not visible.
+
+At the same time, system monitoring showed high memory consumption and CPU saturation. In earlier runs, memory usage increased progressively and reached dangerous levels, with peaks observed around tens of GB. The initial suspicion was that the R pipeline itself was leaking memory.
+
+---
+
+## Initial hotspots identified
+
+### 1. `mclapply()` state-level parallelism
+
+The pipeline processed states in parallel through:
+
+```r
+parallel::mclapply(
+  seq_len(n_states),
+  run_state_pipeline,
+  mc.cores = parallel_cores,
+  mc.preschedule = FALSE
+)
+```
+
+This means each state worker can independently run:
+
+* dengue nowcasting
+* chikungunya nowcasting
+* zika nowcasting
+* INLA Bayesian models
+* database queries
+* RData object generation
+
+The main hotspot was not only the number of R workers, but the fact that each worker could spawn heavy native INLA/MKL processes.
+
+### 2. INLA / MKL / native memory outside R GC
+
+The memory logs added temporarily showed that R heap memory stayed relatively bounded. In one previous run, internal R memory grew only from roughly hundreds of MB to less than 500 MB. However, `htop` showed much larger system memory usage.
+
+This indicated that the main memory pressure was probably not from regular R objects tracked by `gc()`, but from:
+
+* INLA native processes
+* MKL/OpenMP allocations
+* forked R workers
+* native memory outside R GC accounting
+* temporary sparse matrix/model allocations
+* possible copy-on-write pressure caused by `mclapply()`
+
+### 3. Long-lived retained objects inside `run_state_pipeline()`
+
+The original `run_state_pipeline()` kept all disease results in memory until the whole state finished:
+
+```r
+res[["ale.den"]]
+res[["restab.den"]]
+res[["ale.chik"]]
+res[["restab.chik"]]
+res[["ale.zika"]]
+res[["restab.zika"]]
+```
+
+For large states like MG, SP, BA, PR, RS, this increased memory retention.
+
+### 4. Aggregation loaded all state results at once
+
+The previous aggregation stage loaded all `.RData` files into `res_list`:
+
+```r
+res_list <- vector("list", length(file_paths))
+```
+
+This kept all state outputs in memory simultaneously before generating SQL and BR consolidated outputs.
+
+This was a secondary hotspot. It was not the initial crash source, but it increased peak memory after state execution.
+
+### 5. Missing structured error capture
+
+When a worker failed, the pipeline only reported:
+
+```text
+1 function calls resulted in an error
+State pipeline failed for: AL
+```
+
+This made the actual root cause opaque.
+
+## Mitigations implemented in `main_BR.R`
+
+### 1. Split disease execution
+
+We split the disease execution logic into a dedicated function:
+
+```r
+run_disease_pipeline()
+```
+
+Instead of keeping all logic inline inside `run_state_pipeline()`, each disease now has a clearer execution boundary.
+
+Benefits:
+
+* better cohesion
+* easier cleanup after each disease
+* easier error isolation
+* simpler state worker logic
+
+### 2. Added cleanup boundaries
+
+We introduced:
+
+```r
+safe_gc <- function() {
+  invisible(gc(verbose = FALSE))
+}
+```
+
+Cleanup is now triggered:
+
+* after each disease execution
+* after each state save
+* after each loaded `.RData` during aggregation
+* after binding intermediate objects
+* after saving BR RData
+
+Example:
+
+```r
+rm(disease_result)
+safe_gc()
+```
+
+and:
+
+```r
+rm(res, cidades)
+safe_gc()
+```
+
+This helped reduce retained R-side memory and gave workers clearer release points.
+
+### 3. Avoided keeping full `res_list`
+
+The aggregation was refactored to avoid loading all state results into one large `res_list`.
+
+Instead, each `.RData` is loaded, normalized, appended to disease-specific parts, and then cleaned:
+
+```r
+res_k <- load_state_result(file_paths[k])
+...
+rm(res_k)
+safe_gc()
+```
+
+This reduced aggregation memory pressure.
+
+### 4. Improved INLA thread limiting
+
+A new explicit `configure_inla_threads()` function was added:
+
+```r
+configure_inla_threads <- function() {
+  Sys.setenv(
+    OMP_NUM_THREADS = "1",
+    OPENBLAS_NUM_THREADS = "1",
+    MKL_NUM_THREADS = "1",
+    BLIS_NUM_THREADS = "1",
+    VECLIB_MAXIMUM_THREADS = "1",
+    RCPP_PARALLEL_NUM_THREADS = "1",
+    NUMEXPR_NUM_THREADS = "1"
+  )
+
+  INLA::inla.setOption(num.threads = "1:1")
+}
+```
+
+This is called:
+
+* after loading config
+* during INLA runtime validation
+* inside each state worker
+
+Goal:
+
+* reduce nested parallelism
+* avoid MKL/OpenMP oversubscription
+* reduce uncontrolled native thread fanout
+
+Important note: logs still show INLA can emit `thread_num[...]` warnings, so this does not fully eliminate INLA internal native behavior. But it helps constrain the runtime as much as possible from R.
+
+### 5. Restored structured state error capture
+
+A `tryCatch()` wrapper was restored around each state worker.
+
+Now failures report:
+
+* state
+* current step
+* error message
+* call stack
+
+Example structure:
+
+```r
+structure(
+  list(
+    state = sig,
+    step = current_step,
+    message = conditionMessage(e)
+  ),
+  class = "state-error"
+)
+```
+
+This prevents opaque `mclapply()` errors.
+
+### 6. Added municipality-level fallback
+
+When state-level disease execution fails, the pipeline falls back to municipality-level execution:
+
+```r
+run_disease_pipeline_by_city()
+```
+
+This isolates city-level failures and prevents one bad municipality from killing the whole state.
+
+In the successful run, this fallback was triggered for Goiás dengue:
+
+```text
+[state] GO dengue failed in state-level execution: error reading from connection
+[state] GO dengue fallback: municipality-level isolation
+- dengue: retrying municipality-level execution after state-level failure
+```
+
+The state later completed successfully and saved `ale-GO-202618.RData`.  
+
+---
+
+## Test execution summary
+
+### Test run configuration
+
+The successful run used:
+
+```text
+week=202618
+window_weeks=100
+cores=4
+states=ALL
+```
+
+The pipeline started with 27 state rows and 4 parallel workers.  
+
+### Pipeline start
+
+```text
+[2026-05-22 07:50:57] Repo root...
+[2026-05-22 07:51:01] Starting pipeline for 27 state row(s)
+[2026-05-22 07:51:01] State parallel workers: 4
+```
+
+
+
+### Pipeline loop completion
+
+```text
+[2026-05-22 10:18:54] Pipeline loop finished. Elapsed: 2.46473101556301
+```
+
+This means the state-processing phase took about **2.46 hours**, approximately **2h 27m 53s**. 
+
+### Aggregation and SQL generation
+
+After state processing, the pipeline loaded all 27 result files and generated SQL outputs:
+
+```text
+Loaded 27 result file(s)
+Writing SQL dengue
+Writing SQL chik
+No zika restab found. Skipping zika SQL.
+Saving BR RData
+DONE
+```
+
+
+
+### Final Makim completion
+
+```text
+[II] refresh-alertas completed successfully.
+```
+
+
+
+---
+
+## Runtime summary
+
+From logs:
+
+* start: `2026-05-22 07:50:57`
+* state loop finished: `2026-05-22 10:18:54`
+* R pipeline finished: `2026-05-22 10:26:14`
+* SQL apply completed after that
+* Makim completed successfully
+
+Approximate durations:
+
+* state nowcasting loop: **~2h 27m**
+* R pipeline including aggregation/output: **~2h 35m**
+* full workflow including SQL apply: completed successfully, exact final timestamp was not included in the `[II]` completion line
+
+---
+
+## Memory behavior after mitigation
+
+From the monitoring screenshots during the successful run:
+
+* memory stayed bounded
+* peak observed was around **21–26 GB**
+* memory dropped during the run instead of monotonically increasing
+* swap remained low, around a few hundred MB
+* no OOM kill occurred
+* no long stuck worker was observed
+
+This is a major improvement over earlier behavior, where memory appeared to grow continuously and reached much higher levels.
+
+Key interpretation:
+
+* `rm()` + `gc()` boundaries helped reduce R-side retention
+* avoiding full `res_list` helped aggregation
+* limiting to `--cores 4` reduced process concurrency
+* explicit INLA thread configuration likely reduced oversubscription pressure
+* municipality fallback prevented one state/disease failure from killing the run
+
+---
+
+## Remaining warnings and issues
+
+### 1. INLA numerical instability
+
+The logs still show many warnings like:
+
+```text
+iterative process seems to diverge, 'vb.correction' is aborted
+```
+
+These are model/numerical warnings, not infrastructure failures. They indicate convergence instability in some Bayesian nowcasting runs. Examples appear repeatedly in the logs. 
+
+Observed related message:
+
+```text
+inla.core.safe: The inla program failed, but will rerun...
+```
+
+
+
+Impact:
+
+* increases runtime
+* can trigger retries
+* can increase temporary memory usage
+* may indicate unstable model inputs for some municipalities
+
+But in the final run, these warnings did not stop the pipeline.
+
+### 2. `adjustIncidence: city not in dataset`
+
+The logs include many occurrences of:
+
+```text
+Error : adjustIncidence: city not in dataset
+```
+
+This appears mostly during fallback / municipality-level execution. It means some municipality codes are not present in the dataset used by `adjustIncidence`.
+
+Important: this no longer killed the full workflow.
+
+The fallback isolated these failures and allowed the pipeline to continue.
+
+### 3. Zika skipped
+
+The pipeline did not generate zika SQL:
+
+```text
+No zika restab found. Skipping zika SQL.
+```
+
+
+
+This appears expected based on state config or absence of zika outputs, not a pipeline crash.
+
+---
+
+## Outcome
+
+The final implementation successfully mitigated the operational memory issue.
+
+Before:
+
+* opaque `mclapply()` failures
+* state crashes without actionable detail
+* high memory accumulation
+* risk of OOM
+* no fallback for city-level failures
+* aggregation retained all state results
+
+After:
+
+* successful full pipeline execution
+* 27 state outputs loaded
+* dengue SQL generated
+* chik SQL generated
+* BR RData generated
+* Makim completed successfully
+* memory remained bounded
+* municipality-level fallback recovered GO dengue
+* structured logs now identify failures and fallback behavior
+
+---
+
+## Final technical conclusion
+
+The root cause of the memory issue was not a simple R heap leak. The evidence points to a combination of:
+
+* state-level parallelism via `mclapply()`
+* heavy INLA Bayesian nowcasting
+* native memory allocation outside R GC
+* MKL/OpenMP/thread oversubscription risk
+* large retained state objects
+* aggregation loading all outputs into memory
+* lack of cleanup boundaries
+
+The mitigation was effective because it attacked the problem at several levels:
+
+1. reduced retained R objects with explicit cleanup
+2. avoided keeping all state outputs loaded at once
+3. constrained INLA/native threads
+4. limited worker parallelism to `--cores 4`
+5. isolated municipality failures
+6. restored structured state error logging
+
+The final run confirms the approach is operationally stable for week `202618` with all states and `--cores 4`.

--- a/main/main_BR.R
+++ b/main/main_BR.R
@@ -94,20 +94,40 @@ configure_inla_threads <- function() {
     return(invisible(FALSE))
   }
 
-  tryCatch(
+  set_option <- get0(
+    "inla.setOption",
+    envir = asNamespace("INLA"),
+    inherits = FALSE
+  )
+
+  if (!is.function(set_option)) {
+    log_msg(
+      "INLA thread option helper not available; keeping INLA defaults.",
+      level = "WARN"
+    )
+    return(invisible(FALSE))
+  }
+
+  ok <- tryCatch(
     {
-      INLA::inla.setOption(num.threads = "1:1")
-      invisible(TRUE)
+      set_option(num.threads = "1:1")
+      TRUE
     },
     error = function(e) {
       log_msg(
-        "Could not configure INLA threads: ",
+        "Could not set INLA num.threads='1:1': ",
         conditionMessage(e),
         level = "WARN"
       )
-      invisible(FALSE)
+      FALSE
     }
   )
+
+  if (ok) {
+    log_msg("INLA num.threads set to 1:1")
+  }
+
+  invisible(ok)
 }
 
 args0 <- commandArgs(trailingOnly = FALSE)
@@ -298,7 +318,7 @@ connect_db <- function() {
 con_check <- connect_db()
 try(DBI::dbDisconnect(con_check), silent = TRUE)
 log_msg("DB connected OK")
- 
+
 # Publicação opcional dos .RData via scp (independente do banco ser local/remoto).
 do_scp <- tolower(get_env_any(c("ALERTA_DO_SCP"), default = "0")) %in%
   c("1", "true", "yes", "y")
@@ -399,7 +419,14 @@ combine_ale_parts <- function(parts) {
 }
 
 run_city_pipeline <- function(city, cid10, now_mode, disease_label, sig) {
-  tryCatch(
+  log_msg(
+    "[state] ", sig,
+    " ", disease_label,
+    " city=", city,
+    " started"
+  )
+
+  result <- tryCatch(
     {
       pipe_infodengue(
         city,
@@ -416,13 +443,35 @@ run_city_pipeline <- function(city, cid10, now_mode, disease_label, sig) {
       log_msg(
         "[state] ", sig,
         " ", disease_label,
-        " city ", city,
+        " city=", city,
         " failed: ", conditionMessage(e),
         level = "ERROR"
       )
       NULL
+    },
+    warning = function(w) {
+      log_msg(
+        "[state] ", sig,
+        " ", disease_label,
+        " city=", city,
+        " warning: ", conditionMessage(w),
+        level = "WARN"
+      )
+      invokeRestart("muffleWarning")
     }
   )
+
+  if (is.null(result)) {
+    log_msg(
+      "[state] ", sig,
+      " ", disease_label,
+      " city=", city,
+      " returned no result after fallback execution",
+      level = "WARN"
+    )
+  }
+
+  result
 }
 
 run_disease_pipeline_by_city <- function(cidades, cid10, now_mode,

--- a/main/main_BR.R
+++ b/main/main_BR.R
@@ -4,48 +4,112 @@
 
 options(stringsAsFactors = FALSE)
 
-# Logger padronizado para saída em stdout.
 log_msg <- function(..., level = "INFO") {
   ts <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
   msg <- paste0(...)
   cat(sprintf("[%s] [%s] %s\n", ts, level, msg))
 }
 
-# Localiza a raiz do repositório a partir de um diretório inicial, subindo
-# alguns níveis e validando a existência de arquivos-chave do projeto.
 find_repo_root <- function(start_dir) {
   cur <- normalizePath(start_dir, winslash = "/", mustWork = FALSE)
+
   for (i in 1:8) {
     has_main <- file.exists(file.path(cur, "main", "main_BR.R"))
     has_cfg1 <- file.exists(file.path(cur, "config", "config_global_2020.R"))
     has_cfg2 <- file.exists(
       file.path(cur, "AlertaDengueAnalise", "config", "config_global_2020.R")
     )
+
     if (has_main && (has_cfg1 || has_cfg2)) {
       return(cur)
     }
+
     parent <- normalizePath(
       file.path(cur, ".."),
       winslash = "/",
       mustWork = FALSE
     )
-    if (identical(parent, cur)) break
+
+    if (identical(parent, cur)) {
+      break
+    }
+
     cur <- parent
   }
+
   stop("Could not locate repo root from: ", start_dir, call. = FALSE)
 }
 
-# Obtém a primeira variável de ambiente disponível dentre os nomes fornecidos.
 get_env_any <- function(names, default = NULL) {
   for (nm in names) {
     val <- Sys.getenv(nm, unset = "")
-    if (nzchar(val)) return(val)
+    if (nzchar(val)) {
+      return(val)
+    }
   }
+
   default
 }
 
-# Determina o diretório do script em execução para resolução consistente
-# de paths relativos e descoberta da raiz do repositório.
+safe_gc <- function() {
+  invisible(gc(verbose = FALSE))
+}
+
+format_call_stack <- function(max_calls = 20) {
+  calls <- sys.calls()
+  if (length(calls) == 0) {
+    return(character(0))
+  }
+
+  calls <- tail(calls, max_calls)
+  vapply(calls, function(call) paste(deparse(call), collapse = " "), "")
+}
+
+log_call_stack <- function(label) {
+  calls <- format_call_stack()
+  if (length(calls) == 0) {
+    return(invisible(NULL))
+  }
+
+  log_msg(label, " stack:", level = "ERROR")
+  for (line in calls) {
+    log_msg("  ", line, level = "ERROR")
+  }
+
+  invisible(NULL)
+}
+
+configure_inla_threads <- function() {
+  Sys.setenv(
+    OMP_NUM_THREADS = "1",
+    OPENBLAS_NUM_THREADS = "1",
+    MKL_NUM_THREADS = "1",
+    BLIS_NUM_THREADS = "1",
+    VECLIB_MAXIMUM_THREADS = "1",
+    RCPP_PARALLEL_NUM_THREADS = "1",
+    NUMEXPR_NUM_THREADS = "1"
+  )
+
+  if (!requireNamespace("INLA", quietly = TRUE)) {
+    return(invisible(FALSE))
+  }
+
+  tryCatch(
+    {
+      INLA::inla.setOption(num.threads = "1:1")
+      invisible(TRUE)
+    },
+    error = function(e) {
+      log_msg(
+        "Could not configure INLA threads: ",
+        conditionMessage(e),
+        level = "WARN"
+      )
+      invisible(FALSE)
+    }
+  )
+}
+
 args0 <- commandArgs(trailingOnly = FALSE)
 file_arg <- sub("^--file=", "", args0[grep("^--file=", args0)])
 script_dir <- if (length(file_arg)) {
@@ -68,12 +132,14 @@ cfg_path <- if (file.exists(file.path(repo_root, "config",
 log_msg("Loading config: ", cfg_path)
 
 source(cfg_path)
+configure_inla_threads()
 
 # Garante disponibilidade de mclapply (onde rotinas do pipeline usam paralelismo).
 if (!exists("mclapply", mode = "function")) {
   if (!requireNamespace("parallel", quietly = TRUE)) {
     stop("Missing base R package 'parallel'.", call. = FALSE)
   }
+
   mclapply <- parallel::mclapply
   log_msg("Enabled parallel::mclapply()")
 }
@@ -82,6 +148,7 @@ if (!exists("detectCores", mode = "function")) {
   if (!requireNamespace("parallel", quietly = TRUE)) {
     stop("Missing base R package 'parallel'.", call. = FALSE)
   }
+
   detectCores <- parallel::detectCores
   log_msg("Enabled parallel::detectCores()")
 }
@@ -100,8 +167,11 @@ check_inla_runtime <- function() {
 
   tryCatch(
     {
+      configure_inla_threads()
+
       suppressPackageStartupMessages(library(INLA))
       suppressPackageStartupMessages(library(sn))
+
       y <- c(1, 0, 1, 0)
       x <- c(0, 1, 0, 1)
 
@@ -112,63 +182,21 @@ check_inla_runtime <- function() {
           data = data.frame(y = y, x = x),
           control.compute = list(dic = FALSE, waic = FALSE, cpo = FALSE),
           control.predictor = list(compute = FALSE),
-          num.threads = 1,
+          num.threads = "1:1",
           verbose = FALSE
         )
       )
+
       TRUE
     },
     error = function(e) FALSE
   )
 }
 
-has_inla_flag <- check_inla_runtime()
-
-has_inla_flag <- exists("has_inla", inherits = TRUE) && isTRUE(has_inla)
+has_inla_runtime <- check_inla_runtime()
+has_inla_config <- exists("has_inla", inherits = TRUE) && isTRUE(has_inla)
+has_inla_flag <- isTRUE(has_inla_config) && isTRUE(has_inla_runtime)
 log_msg("INLA available: ", has_inla_flag)
-
-configure_inla_threads <- function() {
-  if (!has_inla_flag) {
-    return(invisible(FALSE))
-  }
-
-  set_option <- get0(
-    "inla.setOption",
-    envir = asNamespace("INLA"),
-    inherits = FALSE
-  )
-
-  if (!is.function(set_option)) {
-    log_msg(
-      "INLA thread option helper not available; keeping INLA defaults.",
-      level = "WARN"
-    )
-    return(invisible(FALSE))
-  }
-
-  ok <- tryCatch(
-    {
-      set_option(num.threads = "1:1")
-      TRUE
-    },
-    error = function(e) {
-      log_msg(
-        "Could not set INLA num.threads='1:1': ",
-        conditionMessage(e),
-        level = "WARN"
-      )
-      FALSE
-    }
-  )
-
-  if (ok) {
-    log_msg("INLA num.threads set to 1:1")
-  }
-
-  invisible(ok)
-}
-
-configure_inla_threads()
 
 resolve_nowcasting <- function(mode) {
   if (!identical(mode, "bayesian")) {
@@ -192,6 +220,7 @@ report_epiweek <- as.integer(
     default = NA
   )
 )
+
 if (is.na(report_epiweek)) {
   stop("Missing ALERTA_REPORT_EPIWEEK (expected YYYYWW).", call. = FALSE)
 }
@@ -203,6 +232,7 @@ log_msg("Report end date: ", as.character(report_end_date))
 window_weeks <- as.integer(
   get_env_any(c("ALERTA_WINDOW_WEEKS"), default = "100")
 )
+
 if (is.na(window_weeks) || window_weeks < 1) {
   stop(
     "Invalid ALERTA_WINDOW_WEEKS (expected positive integer).",
@@ -234,8 +264,9 @@ log_msg(" - br_dir:      ", br_dir)
 
 # Parâmetros de conexão ao Postgres (obtidos via ambiente/.env).
 db_host <- get_env_any(c("ALERTA_DB_HOST", "DB_HOST"), default = "127.0.0.1")
-db_port <- as.integer(get_env_any(c("ALERTA_DB_PORT", "DB_PORT"),
-                                  default = "5432"))
+db_port <- as.integer(
+  get_env_any(c("ALERTA_DB_PORT", "DB_PORT"), default = "5432")
+)
 db_name <- get_env_any(c("ALERTA_DB_NAME", "DB_NAME"), default = "dengue")
 db_user <- get_env_any(c("ALERTA_DB_USER", "DB_USER"), default = "")
 db_pass <- get_env_any(c("ALERTA_DB_PASSWORD", "DB_PASSWORD"), default = "")
@@ -244,8 +275,12 @@ if (!nzchar(db_user) || !nzchar(db_pass)) {
   stop("Missing DB_USER/DB_PASSWORD in env (.env).", call. = FALSE)
 }
 
-log_msg("Connecting DB: host=", db_host, " port=", db_port, " dbname=", db_name,
-        " user=", db_user)
+log_msg(
+  "Connecting DB: host=", db_host,
+  " port=", db_port,
+  " dbname=", db_name,
+  " user=", db_user
+)
 
 connect_db <- function() {
   DBI::dbConnect(
@@ -263,7 +298,7 @@ connect_db <- function() {
 con_check <- connect_db()
 try(DBI::dbDisconnect(con_check), silent = TRUE)
 log_msg("DB connected OK")
-
+ 
 # Publicação opcional dos .RData via scp (independente do banco ser local/remoto).
 do_scp <- tolower(get_env_any(c("ALERTA_DO_SCP"), default = "0")) %in%
   c("1", "true", "yes", "y")
@@ -339,208 +374,272 @@ if (n_states == 0) {
 
 log_msg("Starting pipeline for ", n_states, " state row(s)")
 
-parallel_cores <- as.integer(get_env_any(c("ALERTA_PARALLEL_CORES"),
-                                         default = "1"))
+parallel_cores <- as.integer(
+  get_env_any(c("ALERTA_PARALLEL_CORES"), default = "1")
+)
+
 if (is.na(parallel_cores) || parallel_cores < 1) {
-  stop("Invalid ALERTA_PARALLEL_CORES (expected positive integer).",
-       call. = FALSE)
+  stop(
+    "Invalid ALERTA_PARALLEL_CORES (expected positive integer).",
+    call. = FALSE
+  )
 }
+
 parallel_cores <- min(parallel_cores, n_states)
 log_msg("State parallel workers: ", parallel_cores)
 
-log_memory <- function(label, level = "INFO") {
-  gc_info <- gc()
-  used_mb <- NA_real_
+combine_ale_parts <- function(parts) {
+  parts <- Filter(Negate(is.null), parts)
 
-  if (all(c("Ncells", "Vcells") %in% rownames(gc_info)) &&
-      "used" %in% colnames(gc_info)) {
-    used_mb <- (
-      gc_info["Ncells", "used"] * 56 +
-        gc_info["Vcells", "used"] * 8
-    ) / 1024^2
+  if (length(parts) == 0) {
+    return(NULL)
   }
 
-  if (is.na(used_mb)) {
-    log_msg("Memory [", label, "]: gc used=", paste(gc_info[, "used"],
-                                                    collapse = "/"),
-            level = level)
-  } else {
-    log_msg("Memory [", label, "]: approx_used_mb=",
-            sprintf("%.1f", used_mb), level = level)
-  }
+  do.call(c, c(parts, recursive = FALSE))
 }
 
-log_call_stack <- function(label) {
-  calls <- sys.calls()
-  if (length(calls) == 0) {
-    log_msg(label, ": call stack unavailable", level = "ERROR")
-    return(invisible(NULL))
+run_city_pipeline <- function(city, cid10, now_mode, disease_label, sig) {
+  tryCatch(
+    {
+      pipe_infodengue(
+        city,
+        cid10 = cid10,
+        nowcasting = now_mode,
+        finalday = report_end_date,
+        narule = "arima",
+        iniSE = 201001,
+        dataini = "sinpri",
+        completetail = 0
+      )
+    },
+    error = function(e) {
+      log_msg(
+        "[state] ", sig,
+        " ", disease_label,
+        " city ", city,
+        " failed: ", conditionMessage(e),
+        level = "ERROR"
+      )
+      NULL
+    }
+  )
+}
+
+run_disease_pipeline_by_city <- function(cidades, cid10, now_mode,
+                                         disease_label, sig) {
+  log_msg(
+    " - ", disease_label,
+    ": retrying municipality-level execution after state-level failure"
+  )
+
+  ale_parts <- vector("list", length(cidades))
+
+  for (j in seq_along(cidades)) {
+    city <- cidades[[j]]
+    ale_parts[[j]] <- run_city_pipeline(city, cid10, now_mode, disease_label, sig)
+    safe_gc()
   }
 
-  calls <- tail(calls, 12)
-  lines <- vapply(calls, function(call) {
-    paste(deparse(call), collapse = " ")
-  }, character(1))
+  ale <- combine_ale_parts(ale_parts)
+  rm(ale_parts)
+  safe_gc()
 
-  for (line in lines) {
-    log_msg(label, ": ", line, level = "ERROR")
+  if (is.null(ale)) {
+    stop(
+      "All municipality executions failed for ", sig,
+      " / ", disease_label,
+      call. = FALSE
+    )
   }
 
-  invisible(NULL)
+  restab <- tabela_historico(
+    ale,
+    iniSE = report_epiweek - window_weeks
+  )
+
+  list(ale = ale, restab = restab)
+}
+
+run_disease_pipeline <- function(cidades, cid10, now_mode, disease_label, sig) {
+  tryCatch(
+    {
+      ale <- pipe_infodengue(
+        cidades,
+        cid10 = cid10,
+        nowcasting = now_mode,
+        finalday = report_end_date,
+        narule = "arima",
+        iniSE = 201001,
+        dataini = "sinpri",
+        completetail = 0
+      )
+
+      restab <- tabela_historico(
+        ale,
+        iniSE = report_epiweek - window_weeks
+      )
+
+      list(ale = ale, restab = restab)
+    },
+    error = function(e) {
+      log_msg(
+        "[state] ", sig,
+        " ", disease_label,
+        " failed in state-level execution: ", conditionMessage(e),
+        level = "ERROR"
+      )
+
+      log_msg(
+        "[state] ", sig,
+        " ", disease_label,
+        " fallback: municipality-level isolation",
+        level = "WARN"
+      )
+
+      run_disease_pipeline_by_city(cidades, cid10, now_mode, disease_label, sig)
+    }
+  )
+}
+
+store_disease_result <- function(res, disease_result, ale_key, restab_key) {
+  res[[ale_key]] <- disease_result$ale
+  res[[restab_key]] <- disease_result$restab
+  res
 }
 
 run_state_pipeline <- function(i) {
+  configure_inla_threads()
+
   row_i <- estados_Infodengue[i, ]
   estado <- as.character(row_i$estado)
   sig <- as.character(row_i$sigla)
   current_step <- "initializing"
 
-  tryCatch({
-    log_msg(sprintf("[state] %d/%d %s (%s)", i, n_states, estado, sig))
-    log_memory(paste0(sig, " state start"))
+  tryCatch(
+    {
+      log_msg(sprintf("[state] %d/%d %s (%s)", i, n_states, estado, sig))
 
-    current_step <- "connecting database"
-    con <- connect_db()
-    assign("con", con, envir = .GlobalEnv)
-    on.exit(try(DBI::dbDisconnect(con), silent = TRUE), add = TRUE)
+      current_step <- "connecting database"
+      con <- connect_db()
+      assign("con", con, envir = .GlobalEnv)
+      on.exit(try(DBI::dbDisconnect(con), silent = TRUE), add = TRUE)
+      on.exit(safe_gc(), add = TRUE)
 
-    # Arquivo de saída por estado: lista 'res' contendo 'ale.*' e 'restab.*'.
-    nomeRData <- paste0("ale-", sig, "-", report_epiweek, ".RData")
-    out_rdata <- file.path(alertas_dir, nomeRData)
+      nomeRData <- paste0("ale-", sig, "-", report_epiweek, ".RData")
+      out_rdata <- file.path(alertas_dir, nomeRData)
 
-    current_step <- "loading cities"
-    # Municípios (geocódigos) utilizados para cálculo do alerta estadual.
-    cidades <- getCidades(uf = estado)[, "municipio_geocodigo"]
-    if (length(cidades) == 0) {
-      stop("No cities returned for state: ", estado, call. = FALSE)
-    }
+      current_step <- "loading cities"
+      cidades <- getCidades(uf = estado)[, "municipio_geocodigo"]
+      if (length(cidades) == 0) {
+        stop("No cities returned for state: ", estado, call. = FALSE)
+      }
 
-    res <- list()
+      res <- list()
+      now_mode <- resolve_nowcasting("bayesian")
 
-    # Dengue
-    now_mode <- resolve_nowcasting("bayesian")
-    log_msg(" - dengue: running pipe_infodengue (nowcasting=", now_mode, ")")
-    if (isTRUE(row_i$dengue)) {
       current_step <- "dengue pipe_infodengue"
-      log_memory(paste0(sig, " dengue before pipe_infodengue"))
-      log_msg(" - dengue: running pipe_infodengue")
-      res[["ale.den"]] <- pipe_infodengue(
-        cidades,
-        cid10 = "A90",
-        nowcasting = now_mode,
-        finalday = report_end_date,
-        narule = "arima",
-        iniSE = 201001,
-        dataini = "sinpri",
-        completetail = 0
-      )
-      log_memory(paste0(sig, " dengue after pipe_infodengue"))
-      current_step <- "dengue tabela_historico"
-      res[["restab.den"]] <- tabela_historico(
-        res[["ale.den"]],
-        iniSE = report_epiweek - window_weeks
-      )
-      log_memory(paste0(sig, " dengue after tabela_historico"))
-    } else {
-      log_msg(" - dengue: skipped")
-    }
+      log_msg(" - dengue: running pipe_infodengue (nowcasting=", now_mode, ")")
+      if (isTRUE(row_i$dengue)) {
+        disease_result <- run_disease_pipeline(
+          cidades,
+          "A90",
+          now_mode,
+          "dengue",
+          sig
+        )
+        res <- store_disease_result(res, disease_result, "ale.den", "restab.den")
+        rm(disease_result)
+        safe_gc()
+      } else {
+        log_msg(" - dengue: skipped")
+      }
 
-    # Chikungunya
-    now_mode <- resolve_nowcasting("bayesian")
-    log_msg(" - chik: running pipe_infodengue (nowcasting=", now_mode, ")")
-    if (isTRUE(row_i$chik)) {
       current_step <- "chik pipe_infodengue"
-      log_memory(paste0(sig, " chik before pipe_infodengue"))
-      log_msg(" - chik: running pipe_infodengue")
-      res[["ale.chik"]] <- pipe_infodengue(
-        cidades,
-        cid10 = "A92.0",
-        nowcasting = now_mode,
-        finalday = report_end_date,
-        narule = "arima",
-        iniSE = 201001,
-        dataini = "sinpri",
-        completetail = 0
-      )
-      log_memory(paste0(sig, " chik after pipe_infodengue"))
-      current_step <- "chik tabela_historico"
-      res[["restab.chik"]] <- tabela_historico(
-        res[["ale.chik"]],
-        iniSE = report_epiweek - window_weeks
-      )
-      log_memory(paste0(sig, " chik after tabela_historico"))
-    } else {
-      log_msg(" - chik: skipped")
-    }
+      log_msg(" - chik: running pipe_infodengue (nowcasting=", now_mode, ")")
+      if (isTRUE(row_i$chik)) {
+        disease_result <- run_disease_pipeline(
+          cidades,
+          "A92.0",
+          now_mode,
+          "chik",
+          sig
+        )
+        res <- store_disease_result(
+          res,
+          disease_result,
+          "ale.chik",
+          "restab.chik"
+        )
+        rm(disease_result)
+        safe_gc()
+      } else {
+        log_msg(" - chik: skipped")
+      }
 
-    # Zika
-    now_mode <- resolve_nowcasting("bayesian")
-    log_msg(" - zika: running pipe_infodengue (nowcasting=", now_mode, ")")
-    if (isTRUE(row_i$zika)) {
       current_step <- "zika pipe_infodengue"
-      log_memory(paste0(sig, " zika before pipe_infodengue"))
-      log_msg(" - zika: running pipe_infodengue")
-      res[["ale.zika"]] <- pipe_infodengue(
-        cidades,
-        cid10 = "A92.8",
-        nowcasting = now_mode,
-        finalday = report_end_date,
-        narule = "arima",
-        iniSE = 201001,
-        dataini = "sinpri",
-        completetail = 0
+      log_msg(" - zika: running pipe_infodengue (nowcasting=", now_mode, ")")
+      if (isTRUE(row_i$zika)) {
+        disease_result <- run_disease_pipeline(
+          cidades,
+          "A92.8",
+          now_mode,
+          "zika",
+          sig
+        )
+        res <- store_disease_result(
+          res,
+          disease_result,
+          "ale.zika",
+          "restab.zika"
+        )
+        rm(disease_result)
+        safe_gc()
+      } else {
+        log_msg(" - zika: skipped")
+      }
+
+      current_step <- "saving state RData"
+      save(res, file = out_rdata)
+      log_msg("Saved: ", out_rdata)
+
+      rm(res, cidades)
+      safe_gc()
+
+      if (do_scp) {
+        current_step <- "scp state RData"
+        cmd <- paste(
+          "scp -P",
+          shQuote(scp_port),
+          shQuote(out_rdata),
+          shQuote(scp_target)
+        )
+        log_msg("SCP: ", cmd)
+        system(cmd)
+      }
+
+      out_rdata
+    },
+    error = function(e) {
+      log_msg(
+        "[state] failed ", sig,
+        " during ", current_step,
+        ": ", conditionMessage(e),
+        level = "ERROR"
       )
-      log_memory(paste0(sig, " zika after pipe_infodengue"))
-      current_step <- "zika tabela_historico"
-      res[["restab.zika"]] <- tabela_historico(
-        res[["ale.zika"]],
-        iniSE = report_epiweek - window_weeks
+
+      log_call_stack(paste0("[state] ", sig))
+      safe_gc()
+
+      structure(
+        list(
+          state = sig,
+          step = current_step,
+          message = conditionMessage(e)
+        ),
+        class = "state-error"
       )
-      log_memory(paste0(sig, " zika after tabela_historico"))
-    } else {
-      log_msg(" - zika: skipped")
     }
-
-    current_step <- "saving state RData"
-    log_memory(paste0(sig, " before save"))
-    save(res, file = out_rdata)
-    log_msg("Saved: ", out_rdata)
-    log_memory(paste0(sig, " after save"))
-
-    if (do_scp) {
-      current_step <- "scp state RData"
-      cmd <- paste(
-        "scp -P",
-        shQuote(scp_port),
-        shQuote(out_rdata),
-        shQuote(scp_target)
-      )
-      log_msg("SCP: ", cmd)
-      system(cmd)
-    }
-
-    out_rdata
-  }, error = function(e) {
-    log_msg(
-      "[state] failed ",
-      sig,
-      " during ",
-      current_step,
-      ": ",
-      conditionMessage(e),
-      level = "ERROR"
-    )
-    log_call_stack(paste0("[state] ", sig, " call"))
-    log_memory(paste0(sig, " failure"), level = "ERROR")
-    structure(
-      list(
-        state = sig,
-        step = current_step,
-        message = conditionMessage(e)
-      ),
-      class = "state-error"
-    )
-  })
+  )
 }
 
 # Execução do pipeline por linha da configuração de estados.
@@ -555,22 +654,40 @@ state_outputs <- if (parallel_cores > 1 && n_states > 1) {
   lapply(seq_len(n_states), run_state_pipeline)
 }
 
-failed_states <- vapply(state_outputs, function(x) {
-  inherits(x, "try-error") || inherits(x, "state-error")
-}, logical(1))
+failed_states <- vapply(state_outputs, inherits, logical(1), "state-error")
+failed_try_errors <- vapply(state_outputs, inherits, logical(1), "try-error")
+failed_states <- failed_states | failed_try_errors
+
 if (any(failed_states)) {
-  failed_labels <- paste(estados_Infodengue$sigla[failed_states],
-                         collapse = ", ")
-  failure_messages <- vapply(state_outputs[failed_states], function(x) {
-    if (inherits(x, "state-error")) {
-      paste0(x$state, " during ", x$step, ": ", x$message)
-    } else {
-      as.character(x)
+  failed_outputs <- state_outputs[failed_states]
+  failed_labels <- vapply(
+    seq_along(failed_outputs),
+    function(idx) {
+      item <- failed_outputs[[idx]]
+      if (inherits(item, "state-error") && !is.null(item$state)) {
+        return(item$state)
+      }
+      estados_Infodengue$sigla[failed_states][[idx]]
+    },
+    ""
+  )
+
+  for (item in failed_outputs) {
+    if (inherits(item, "state-error")) {
+      log_msg(
+        "Failed state summary: state=", item$state,
+        " step=", item$step,
+        " message=", item$message,
+        level = "ERROR"
+      )
     }
-  }, character(1))
-  log_msg("State failure details: ", paste(failure_messages, collapse = " | "),
-          level = "ERROR")
-  stop("State pipeline failed for: ", failed_labels, call. = FALSE)
+  }
+
+  stop(
+    "State pipeline failed for: ",
+    paste(failed_labels, collapse = ", "),
+    call. = FALSE
+  )
 }
 
 t2 <- Sys.time()
@@ -583,44 +700,118 @@ if (length(file_paths) == 0) {
   stop("No .RData files found in: ", alertas_dir, call. = FALSE)
 }
 
-# Carrega cada arquivo em ambiente isolado e coleta o objeto 'res'.
-res_list <- vector("list", length(file_paths))
-for (k in seq_along(file_paths)) {
-  env_k <- new.env(parent = emptyenv())
-  load(file_paths[k], envir = env_k)
-  if (!exists("res", envir = env_k, inherits = FALSE)) {
-    stop("Missing object 'res' inside: ", file_paths[k], call. = FALSE)
+load_state_result <- function(path) {
+  env <- new.env(parent = emptyenv())
+  load(path, envir = env)
+
+  if (!exists("res", envir = env, inherits = FALSE)) {
+    stop("Missing object 'res' inside: ", path, call. = FALSE)
   }
-  res_list[[k]] <- env_k$res
-}
-log_msg("Loaded ", length(res_list), " result file(s)")
 
-# Consolida as tabelas históricas ('restab.*') dos estados.
-combine_restab <- function(key) {
-  parts <- lapply(res_list, function(r) r[[key]])
+  env$res
+}
+
+append_part <- function(parts, value) {
+  if (!is.null(value)) {
+    parts[[length(parts) + 1]] <- value
+  }
+
+  parts
+}
+
+normalize_restab <- function(x) {
+  if (is.null(x)) {
+    return(NULL)
+  }
+
+  if (is.list(x) && !is.data.frame(x)) {
+    return(dplyr::bind_rows(x))
+  }
+
+  x
+}
+
+normalize_ale <- function(x) {
+  if (is.null(x)) {
+    return(NULL)
+  }
+
+  tr <- transpose(x)
+  data <- dplyr::bind_rows(tr[[1]])
+  idx <- dplyr::bind_rows(tr[[2]])
+
+  cbind(data, idx)
+}
+
+bind_parts <- function(parts) {
   parts <- Filter(Negate(is.null), parts)
-  if (length(parts) == 0) return(NULL)
 
-  dfs <- lapply(parts, function(x) {
-    if (is.list(x) && !is.data.frame(x)) {
-      dplyr::bind_rows(x)
-    } else {
-      x
-    }
-  })
-  dplyr::bind_rows(dfs)
+  if (length(parts) == 0) {
+    return(NULL)
+  }
+
+  dplyr::bind_rows(parts)
 }
 
-restab_den <- combine_restab("restab.den")
-restab_chik <- combine_restab("restab.chik")
-restab_zika <- combine_restab("restab.zika")
+restab_den_parts <- list()
+restab_chik_parts <- list()
+restab_zika_parts <- list()
+ale_den_parts <- list()
+ale_chik_parts <- list()
+ale_zika_parts <- list()
 
-# Ajuste de segurança para valores extremos de 'casos_est_max'.
+for (k in seq_along(file_paths)) {
+  res_k <- load_state_result(file_paths[k])
+
+  restab_den_parts <- append_part(
+    restab_den_parts,
+    normalize_restab(res_k[["restab.den"]])
+  )
+  restab_chik_parts <- append_part(
+    restab_chik_parts,
+    normalize_restab(res_k[["restab.chik"]])
+  )
+  restab_zika_parts <- append_part(
+    restab_zika_parts,
+    normalize_restab(res_k[["restab.zika"]])
+  )
+
+  ale_den_parts <- append_part(
+    ale_den_parts,
+    normalize_ale(res_k[["ale.den"]])
+  )
+  ale_chik_parts <- append_part(
+    ale_chik_parts,
+    normalize_ale(res_k[["ale.chik"]])
+  )
+  ale_zika_parts <- append_part(
+    ale_zika_parts,
+    normalize_ale(res_k[["ale.zika"]])
+  )
+
+  rm(res_k)
+  safe_gc()
+}
+
+log_msg("Loaded ", length(file_paths), " result file(s)")
+
+restab_den <- bind_parts(restab_den_parts)
+restab_chik <- bind_parts(restab_chik_parts)
+restab_zika <- bind_parts(restab_zika_parts)
+
+rm(restab_den_parts, restab_chik_parts, restab_zika_parts)
+safe_gc()
+
+# Ajuste de segurança para valores extremos de 'casos_est_max'
 cap_max <- function(df) {
-  if (is.null(df)) return(NULL)
+  if (is.null(df)) {
+    return(NULL)
+  }
+
   if ("casos_est_max" %in% names(df)) {
     df$casos_est_max[df$casos_est_max > 10000] <- NA
   }
+
   df
 }
 
@@ -653,24 +844,15 @@ if (!is.null(restab_zika)) {
   log_msg("No zika restab found. Skipping zika SQL.", level = "WARN")
 }
 
-# Consolida as estruturas 'ale.*' para produzir um RData agregado nacional.
-collect_ale <- function(key) {
-  parts <- lapply(res_list, function(r) r[[key]])
-  parts <- Filter(Negate(is.null), parts)
-  if (length(parts) == 0) return(NULL)
+rm(restab_den, restab_chik, restab_zika)
+safe_gc()
 
-  rows <- lapply(parts, function(x) {
-    tr <- transpose(x)
-    data <- dplyr::bind_rows(tr[[1]])
-    idx <- dplyr::bind_rows(tr[[2]])
-    cbind(data, idx)
-  })
-  dplyr::bind_rows(rows)
-}
+ale_den <- bind_parts(ale_den_parts)
+ale_chik <- bind_parts(ale_chik_parts)
+ale_zika <- bind_parts(ale_zika_parts)
 
-ale_den <- collect_ale("ale.den")
-ale_chik <- collect_ale("ale.chik")
-ale_zika <- collect_ale("ale.zika")
+rm(ale_den_parts, ale_chik_parts, ale_zika_parts)
+safe_gc()
 
 # Combine all available disease data for the BR consolidated RData.
 # Use dplyr::bind_rows so that columns present in some but not all disease
@@ -678,12 +860,17 @@ ale_zika <- collect_ale("ale.zika")
 parts_br <- Filter(Negate(is.null), list(ale_den, ale_chik, ale_zika))
 d <- if (length(parts_br) > 0) dplyr::bind_rows(parts_br) else NULL
 
+rm(ale_den, ale_chik, ale_zika, parts_br)
+safe_gc()
+
 if (is.null(d)) {
   log_msg("No 'ale.*' data found. Skipping BR RData.", level = "WARN")
 } else {
   out_br <- file.path(br_dir, paste0("ale-BR-", report_epiweek, ".RData"))
   log_msg("Saving BR RData: ", out_br)
   save(d, file = out_br)
+  rm(d)
+  safe_gc()
 }
 
 log_msg("DONE")


### PR DESCRIPTION
### Description:

Split disease execution into isolated pipeline stages, add cleanup boundaries with safe_gc(), avoid loading all state results into memory during aggregation, and improve worker isolation for municipality-level failures during Bayesian nowcasting.

- closes #37.
- refers to #24 24.